### PR TITLE
36 query params geocoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.8.0] - 2019-03-22
+### Fixes
+- Includes `APIGeoJSONQueryParams` in `__all__` for `base_API_query.py`
+
 ### Adds
 - Adds `APIGeocoderQueryParams`, which, when called form
   `BaseAPIQuery.query_api_df`, returns a `DataFrame` with the geographic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.8.0] - 2019-03-22
+### Adds
+- Adds `APIGeocoderQueryParams`, which, when called form
+  `BaseAPIQuery.query_api_df`, returns a `DataFrame` with the geographic
+  information associated with a latitude-longitude pair.
+  
+  Example: 
+  ```python 
+  from strato_query.base_API_query import BaseAPIQuery, APIGeocoderQueryParams
+
+  BaseAPIQuery.query_api_df(
+    query_params=APIGeocoderQueryParams(
+        data_fields=('geoid11', 'geoid5',),
+        table='geocookbook_tract_na_shapes_full',
+        data_filters=(),
+        groupby=(),
+        aggregations=(),
+        latitude=42.983899,
+        longitude=-99.306204))
+  ```
+  
+  ```
+         GEOID11  GEOID5
+  0  31103975400   31103
+  ```
+
 ## [2.7.0] - 2019-03-07
 ### Adds
 - Adds `APIGeoJSONQueryParams`, which, when called from
@@ -10,6 +36,8 @@ All notable changes to this project will be documented in this file. This projec
   `Feature`.
   
   ```python
+  from strato_query.base_API_query import BaseAPIQuery, APIGeoJSONQueryParams, APIQueryParams
+
   BaseAPIQuery.query_api_json(
     query_params=APIGeoJSONQueryParams(
         data_fields=('geoid2', 'geometry'),

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from setuptools import setup
 
 setup(
     name='strato_query',
-    version='2.7.0',
+    version='2.8.0',
     author='Michael Clawar, Raaid Arshad, Eric Linden',
     author_email='tech@stratodem.com',
     packages=[

--- a/strato_query/base_API_query.py
+++ b/strato_query/base_API_query.py
@@ -21,6 +21,7 @@ from strato_query.core import constants as cc
 
 __all__ = [
     'APIQueryParams', 'BaseAPIQuery', 'APIMeanQueryParams', 'APIMedianQueryParams',
+    'APIGeoJSONQueryParams', 'APIGeocoderQueryParams',
 ]
 
 API_TOKEN = os.environ.get('API_TOKEN')
@@ -485,6 +486,36 @@ class APIGeoJSONQueryParams(APIQueryParams):
         return self._properties
 
 
+class APIGeocoderQueryParams(APIQueryParams):
+    def __init__(self, latitude: Union[int, float], longitude: Union[int, float], **kwargs):
+        assert isinstance(latitude, (int, float))
+        assert isinstance(longitude, (int, float))
+
+        super().__init__(**kwargs)
+
+        self._latitude = latitude
+        self._longitude = longitude
+
+    def to_api_struct(self):
+        return_dict = super().to_api_struct()
+        return_dict['latitude'] = self.latitude
+        return_dict['longitude'] = self.longitude
+
+        return return_dict
+
+    @property
+    def query_type(self) -> str:
+        return 'GEOCODER'
+
+    @property
+    def latitude(self) -> Union[float, int]:
+        return self._latitude
+
+    @property
+    def longitude(self) -> Union[float, int]:
+        return self._longitude
+
+
 class BaseAPIQuery:
     @classmethod
     def submit_query(cls, query_params: Optional[APIQueryParams] = None,
@@ -571,25 +602,12 @@ if __name__ == '__main__':
     import json
 
     print(
-        json.dumps(
-            BaseAPIQuery.query_api_json(
-                query_params=APIGeoJSONQueryParams(
-                    data_fields=('geoid2', 'geometry'),
-                    table='geocookbook_state_na_shapes_simplified',
-                    properties=('geoid2', 'population'),
-                    data_filters=(
-                        {'filter_type': 'eq', 'filter_variable': 'geoid2', 'filter_value': 25},
-                    ),
-                    aggregations=(),
-                    groupby=(),
-                    join=APIQueryParams(
-                        table='populationforecast_state_annual_population',
-                        data_fields=({'geoid2': 'geoid2_pop'}, 'population'),
-                        aggregations=(),
-                        data_filters=(
-                            {'filter_type': 'eq', 'filter_variable': 'year', 'filter_value': 2019},
-                        ),
-                        groupby=(),
-                        on=dict(left=['geoid2'], right=['geoid2_pop'])
-                    ),
-                ))))
+        BaseAPIQuery.query_api_df(
+            query_params=APIGeocoderQueryParams(
+                data_fields=('geoid11', 'geoid5',),
+                table='geocookbook_tract_na_shapes_full',
+                data_filters=(),
+                groupby=(),
+                aggregations=(),
+                latitude=42.983899,
+                longitude=-99.306204)))

--- a/strato_query/base_API_query.py
+++ b/strato_query/base_API_query.py
@@ -236,9 +236,9 @@ class APIQueryParams(abc.ABC):
                         filter_value = fv
                     return '{func}(filterVariable:="{filter_variable}", ' \
                            'filterValue:={filter_value})'.format(
-                        func=func,
-                        filter_variable=filt['filter_variable'],
-                        filter_value=filter_value)
+                            func=func,
+                            filter_variable=filt['filter_variable'],
+                            filter_value=filter_value)
 
             def _process_aggregation(agg: dict) -> str:
                 assert isinstance(agg, dict)
@@ -358,9 +358,9 @@ class APIQueryParams(abc.ABC):
                         filter_value = fv
                     return '{func}(filter_variable = "{filter_variable}", ' \
                            'filter_value = {filter_value})'.format(
-                        func=func,
-                        filter_variable=filt['filter_variable'],
-                        filter_value=filter_value)
+                            func=func,
+                            filter_variable=filt['filter_variable'],
+                            filter_value=filter_value)
 
             def _process_aggregation(agg: dict) -> str:
                 assert isinstance(agg, dict)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- MANDATORY -->
<!--- Always fill out a description and motivation. If it is something truly trivial or simple, it is okay to keep it short and sweet. -->
## Description
<!--- Describe your changes in detail and link to the issue that is driving this pull request (if any). Granular changes are ideally listed in your commit messages; the description here should be addressing an Epic and describe what features were added, or addressing a bug and describing what was fixed.-->
### Fixes
- Includes `APIGeoJSONQueryParams` in `__all__` for `base_API_query.py`

### Adds
- Adds `APIGeocoderQueryParams`, which, when called form
  `BaseAPIQuery.query_api_df`, returns a `DataFrame` with the geographic
  information associated with a latitude-longitude pair.
  
  Example: 
  ```python 
  from strato_query.base_API_query import BaseAPIQuery, APIGeocoderQueryParams

  BaseAPIQuery.query_api_df(
    query_params=APIGeocoderQueryParams(
        data_fields=('geoid11', 'geoid5',),
        table='geocookbook_tract_na_shapes_full',
        data_filters=(),
        groupby=(),
        aggregations=(),
        latitude=42.983899,
        longitude=-99.306204))
  ```
  
  ```
         GEOID11  GEOID5
  0  31103975400   31103
  ```

## What does this address?
<!--- What bug does this fix? What issues does this close? What Epic has been furthered along? What milestones have been achieved ahead of/on/behind schedule?-->
Closes #36 
