### PR TITLE
121 wait time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.8.0] - 2020-07-31
+### Adds
+- Adds a new arg, `time_between_chunks`, to the `query_api_multiple` method
+  By default, this arg is set to `None`, which will preserve existing behavior for unchanged queries. When given a value, the method will sleep for the specified time after each chunk is POSTed, and will continue to do so until all chunks have been submitted. The method will not sleep after the final chunk
+
+## Related issues
+- [121](https://github.com/StratoDem/strato-query/issues/121)
+
 ## [3.7.0] - 2019-05-15
 ### Adds
 - Adds new query param classes:

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from setuptools import setup
 
 setup(
     name='strato_query',
-    version='3.7.0',
+    version='3.8.0',
     author='Michael Clawar, Raaid Arshad, Eric Linden',
     author_email='tech@stratodem.com',
     packages=[

--- a/strato_query/__tests__/test_api_query.py
+++ b/strato_query/__tests__/test_api_query.py
@@ -712,14 +712,15 @@ class TestAPIQuery(unittest.TestCase, SDAPIQuery):
         df = self.submit_query(
             query_params=APIDrivingDistanceQueryParams(
                 traffic=True,
+                start_time='2019-05-25T18:00:00',
                 start_latitude=41.82937349570897,
                 start_longitude=-71.41338050365448,
                 end_latitude=42.35339843570063,
                 end_longitude=-71.06788516044617))
         assert 'DISTANCE' in df
-        self.assertAlmostEqual(df['DISTANCE'][0], 44.4448863636), df['DISTANCE'][0]
+        self.assertAlmostEqual(df['DISTANCE'][0], 44.96875), df['DISTANCE'][0]
         assert 'TIME' in df
-        self.assertAlmostEqual(df['TIME'][0], 56.7833333333), df['TIME'][0]
+        self.assertAlmostEqual(df['TIME'][0], 60.08333333333), df['TIME'][0]
 
     def test_walking_distance_query(self):
         df = self.submit_query(

--- a/strato_query/api_query.py
+++ b/strato_query/api_query.py
@@ -165,7 +165,7 @@ class SDAPIQuery:
                 df_ = pandas.DataFrame(v)
                 df_.columns = [c.upper() for c in df_.columns]
                 df_dict[k] = df_
-            if time_between_chunks is not None and idx_chunk + chunksize < len(keys_list):
+            if time_between_chunks is not None and (idx_chunk + chunksize) < len(keys_list):
                 time.sleep(time_between_chunks)
 
         return df_dict

--- a/strato_query/api_query.py
+++ b/strato_query/api_query.py
@@ -123,6 +123,7 @@ class SDAPIQuery:
     def query_api_multiple(queries: Dict[str, APIQueryParams],
                            timeout: Optional[float] = 60.0,
                            chunksize: int = 500,
+                           time_between_chunks: Optional[float] = None,
                            headers: Optional[Dict[str, str]] = None) -> Dict[str, pandas.DataFrame]:
         """
         Submits the query params and returns the resulting data
@@ -135,6 +136,8 @@ class SDAPIQuery:
             The time allowed before a request times out, where 1 second is 1.0
         chunksize: int=500
             The maximum size of chunks submitted to the API service at once
+        time_between_chunks: Optional[float] = None
+            The time (where 1 second is 1.0) to wait between sending chunks
         headers: Optional[Dict[str, str]] = None
             Optional request headers
 
@@ -162,6 +165,8 @@ class SDAPIQuery:
                 df_ = pandas.DataFrame(v)
                 df_.columns = [c.upper() for c in df_.columns]
                 df_dict[k] = df_
+            if time_between_chunks is not None and idx_chunk + chunksize < len(keys_list):
+                time.sleep(time_between_chunks)
 
         return df_dict
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- MANDATORY -->
<!--- Always fill out a description and motivation. If it is something truly trivial or simple, it is okay to keep it short and sweet. -->
## Description
<!--- Describe your changes in detail and link to the issue that is driving this pull request (if any). Granular changes are ideally listed in your commit messages; the description here should be addressing an Epic and describe what features were added, or addressing a bug and describing what was fixed.-->
Adds a new arg, `time_between_chunks`, to the `query_api_multiple` method
  By default, this arg is set to `None`, which will preserve existing behavior for unchanged queries. When given a value, the method will sleep for the specified time after each chunk is POSTed, and will continue to do so until all chunks have been submitted. The method will not sleep after the final chunk

## What does this address?
<!--- What bug does this fix? What issues does this close? What Epic has been furthered along? What milestones have been achieved ahead of/on/behind schedule?-->
Closes #121 

## How has this been tested?
<!--- Did you run the appropriate tests on your components? Did you add any as needed? -->
Manual test with a rate-limited API proved that, when set for the proper values, this will keep the API calls within the allowed quota, and will only sleep while chunks remain.

