### PR TITLE
Add SDJobRunner object for querying data using StratoDem Views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.9.0] - 2020-09-24
+### Adds
+- Adds `SDJobRunner`, a utility object that allows for querying StratoDem Analytics models by creating jobs
+```python
+from strato_query import SDJobRunner, authenticate_to_api
+
+authenticate_to_api('my-api-token')
+
+# This loads a query set defined in the client portal for the Boston and Austin MSAs
+df = SDJobRunner().load_df_from_job_pipeline(
+    model_id='5ADyVKql',
+    geolevel='METRO',
+    geoid_list=[14454, 12420]
+)
+```
+
 ## [3.8.1] - 2020-09-11
 ### Adds
 - Adds support for `walktime_simple` and `walktime_destination_simple`

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from setuptools import setup
 
 setup(
     name='strato_query',
-    version='3.8.1',
+    version='3.9.0',
     author='Michael Clawar, Raaid Arshad, Eric Linden',
     author_email='tech@stratodem.com',
     packages=[

--- a/strato_query/__init__.py
+++ b/strato_query/__init__.py
@@ -9,7 +9,7 @@ Notes :
 December 26, 2018
 """
 
-from .api_query import SDAPIQuery
+from .api_query import SDAPIQuery, SDJobRunner
 from .authentication import authenticate_to_api
 from .filters import *
 from .aggregations import *

--- a/strato_query/__tests__/test_api_query.py
+++ b/strato_query/__tests__/test_api_query.py
@@ -10,6 +10,7 @@ December 26, 2018
 """
 
 import unittest
+import time
 
 from strato_query import *
 
@@ -753,3 +754,37 @@ class TestAPIQuery(unittest.TestCase, SDAPIQuery):
 
         self.assertTrue(df['CATEGORY'].eq(1).all())
         self.assertTrue(df[df['ADDRESS'].map(lambda x: 'Trader Joe\'s' in x)]['ADDRESS'].any())
+
+    def test_job_runner(self):
+        job_runner = SDJobRunner()
+        job_runner.create_job(
+            # Same job
+            model_id='5ADyVKql',
+            geolevel='METRO',
+            geoid_list=[14454, 48620, 12420])
+
+        time.sleep(5)
+
+        df = job_runner.download_job_to_dataframe()
+        self.assertEqual(len(df['GEOID'].unique()), 3, df)
+
+        # Test with JSON file
+        job_runner.create_job(
+            # Same job
+            model_id='5ADyVKql',
+            geolevel='METRO',
+            response_format='json',
+            geoid_list=[14454, 48620])
+
+        time.sleep(5)
+
+        df = job_runner.download_job_to_dataframe()
+        self.assertEqual(len(df['GEOID'].unique()), 2)
+
+        # One line to run entire job pipeline
+        df = SDJobRunner().load_df_from_job_pipeline(
+            # Same job
+            model_id='5ADyVKql',
+            geolevel='METRO',
+            geoid_list=[14454, 48620, 12420])
+        self.assertEqual(len(df['GEOID'].unique()), 3, df)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- MANDATORY -->
<!--- Always fill out a description and motivation. If it is something truly trivial or simple, it is okay to keep it short and sweet. -->
## Description
<!--- Describe your changes in detail and link to the issue that is driving this pull request (if any). Granular changes are ideally listed in your commit messages; the description here should be addressing an Epic and describe what features were added, or addressing a bug and describing what was fixed.-->
### Adds
- Adds `SDJobRunner`, a utility object that allows for querying StratoDem Analytics models by creating jobs
```python
from strato_query import SDJobRunner, authenticate_to_api

authenticate_to_api('my-api-token')

# This loads a query set defined in the client portal for the Boston and Austin MSAs
df = SDJobRunner().load_df_from_job_pipeline(
    model_id='5ADyVKql',
    geolevel='METRO',
    geoid_list=[14454, 12420]
)
```