### PR TITLE
Support chunksize and timeout configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.9.9] - 2021-04-23
+### Changes
+- `chunksize` may now be set globally for multiple queries with configuration variable in `api_query.api_configuration['chunksize']`
+- `timeout` may now be set globally for multiple queries with configuration variable in `api_query.api_configuration['timeout']`
+
 ## [3.9.8] - 2021-02-24
 ### Adds
 - Adds new allowed buffer values

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Core requirements
-Cython==0.29.22
-numpy==1.20.1
-pandas==1.2.2
-requests
+Cython==0.29.23
+numpy==1.20.2
+pandas==1.2.4
+requests==2.25.1

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='strato_query',
-    version='3.9.8',
+    version='3.9.9',
     author='Michael Clawar, Raaid Arshad, Eric Linden',
     author_email='tech@stratodem.com',
     packages=[

--- a/strato_query/__tests__/test_api_query.py
+++ b/strato_query/__tests__/test_api_query.py
@@ -13,6 +13,7 @@ import unittest
 import time
 
 from strato_query import *
+from strato_query.api_query import api_configuration
 
 
 class TestAPIQuery(unittest.TestCase, SDAPIQuery):
@@ -98,6 +99,7 @@ class TestAPIQuery(unittest.TestCase, SDAPIQuery):
         assert df['NAME'].values[1] == 'Plymouth County, MA'
 
     def test_multi_query(self):
+        api_configuration['chunksize'] = 250
         df_dict = self.submit_query(
             queries_params=dict(
                 query_1=APIQueryParams(
@@ -699,7 +701,7 @@ class TestAPIQuery(unittest.TestCase, SDAPIQuery):
         self.assertAlmostEqual(df['DISTANCE'][0], 40.3163963879), df['DISTANCE'][0]
 
     def test_driving_distance_query(self):
-        expected_drivetime = 60.133
+        expected_drivetime = 60.117
 
         df = self.submit_query(
             query_params=APIDrivingDistanceQueryParams(
@@ -796,9 +798,25 @@ class TestAPIQuery(unittest.TestCase, SDAPIQuery):
         df = SDJobRunner().load_df_from_job_pipeline(
             # Same job
             portfolio_id='WMqA42Dw',
-            model_id='Z07RGYoR',
+            model_id='XYjooEDw',
             buffers=['three-mile', 'ten-min'])
+
         self.assertEqual(len(df['GEOID'].unique()), 5, df)
+        self.assertEqual(len(df['BUFFER'].unique()), 2, df)
+
+    def test_job_runner_with_portfolio_time_series(self):
+        # One line to run entire job pipeline
+        df = SDJobRunner().load_df_from_job_pipeline(
+            # Same job
+            portfolio_id='WMqA42Dw',
+            model_id='XYjooEDw',  # This is a time series query
+            buffers=['three-mile', 'ten-min'])
+
+        self.assertEqual(len(df['GEOID'].unique()), 5, df)
+        self.assertEqual(
+            list(df['METRIC'].unique()),
+            ['Employment (payroll survey) * (Time Series)'])
+        self.assertTrue(df['YEAR'].between(2005, 2050).all())
         self.assertEqual(len(df['BUFFER'].unique()), 2, df)
 
     def test_job_runner_with_sites(self):

--- a/strato_query/__tests__/test_api_query.py
+++ b/strato_query/__tests__/test_api_query.py
@@ -798,7 +798,7 @@ class TestAPIQuery(unittest.TestCase, SDAPIQuery):
         df = SDJobRunner().load_df_from_job_pipeline(
             # Same job
             portfolio_id='WMqA42Dw',
-            model_id='XYjooEDw',
+            model_id='Z07RGYoR',
             buffers=['three-mile', 'ten-min'])
 
         self.assertEqual(len(df['GEOID'].unique()), 5, df)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- MANDATORY -->
<!--- Always fill out a description and motivation. If it is something truly trivial or simple, it is okay to keep it short and sweet. -->
## Description
<!--- Describe your changes in detail and link to the issue that is driving this pull request (if any). Granular changes are ideally listed in your commit messages; the description here should be addressing an Epic and describe what features were added, or addressing a bug and describing what was fixed.-->
### Changes
- `chunksize` may now be set globally for multiple queries with configuration variable in `api_query.api_configuration['chunksize']`
- `timeout` may now be set globally for multiple queries with configuration variable in `api_query.api_configuration['timeout']`

## How has this been tested?
<!--- Did you run the appropriate tests on your components? Did you add any as needed? -->
Tested changing chunksize for external calls

